### PR TITLE
Optional Deepspeed to train_n_eval.py

### DIFF
--- a/ab/gen/conf/deepspeed_config.json
+++ b/ab/gen/conf/deepspeed_config.json
@@ -1,0 +1,23 @@
+{
+    "zero_optimization": {
+        "stage": 3,
+        "offload_optimizer": {
+            "device": "cpu",
+            "pin_memory": true
+        },
+        "offload_param": {
+            "device": "cpu",
+            "pin_memory": true
+        },
+        "overlap_comm": true,
+        "contiguous_gradients": true,
+        "sub_group_size": 1e9,
+        "reduce_bucket_size": "auto",
+        "stage3_prefetch_bucket_size": "auto",
+        "stage3_param_persistence_threshold": "auto",
+        "stage3_max_live_parameters": 1e9,
+        "stage3_max_reuse_distance": 1e9,
+        "stage3_gather_16bit_weights_on_model_save": true
+    },
+    "train_micro_batch_size_per_gpu":1
+}

--- a/ab/gen/train_n_eval.py
+++ b/ab/gen/train_n_eval.py
@@ -2,6 +2,7 @@ import json
 import os
 import shutil
 from pathlib import Path
+import deepspeed
 
 import torch
 import torchvision
@@ -25,6 +26,9 @@ base_model_name = "deepseek-ai/deepseek-coder-1.3b-instruct" # "meta-llama/CodeL
 num_epochs = 100
 num_test_epochs = 2
 
+# Deepspeed
+use_deepspeed = False
+ds_config = os.path.join("ab","gen","deepspeed_config.json")
 
 def main():
     bnb_config = BitsAndBytesConfig(
@@ -32,6 +36,23 @@ def main():
         bnb_4bit_use_double_quant=True,
         bnb_4bit_quant_type="nf4",
         bnb_4bit_compute_dtype=torch.bfloat16,
+    )
+
+    # When using deepspeed, no Training arguments' initialization after model initialization, if pre-trained model is used 
+    # Reference: https://huggingface.co/docs/transformers/deepspeed?zero-config=ZeRO-3
+    # With the claim: "The TrainingArguments object must be created before calling the model from_pretrained()"
+    training_args = TrainingArguments(
+        report_to=None,
+        per_device_train_batch_size=1,
+        gradient_accumulation_steps=4,
+        warmup_steps=2,
+        num_train_epochs=1,
+        learning_rate=2e-4,
+        fp16=True,
+        logging_steps=1,
+        output_dir="outputs",
+        optim="paged_adamw_8bit",
+        deepspeed=ds_config,
     )
 
 
@@ -50,9 +71,14 @@ def main():
         base_model_name,
         bnb_config,
         access_token=access_token,
+        use_deepspeed=use_deepspeed,
     )
 
     model, tokenizer = model_loader.get_model(), model_loader.get_tokenizer()
+
+    # initialize deepspeed before we do infer in ChatBot, for trainer is not initialized now.
+    if use_deepspeed:
+        engine = deepspeed.initialize(model=model, config_params=ds_config)
 
     print("Using Max Length:", model_loader.get_max_length())
     data_processor = CodePromptPreprocessor(model_loader.get_max_length(), tokenizer, "./Dataset")
@@ -61,19 +87,6 @@ def main():
     ds_updated = False
 
     print(dataset)
-
-    training_args = TrainingArguments(
-        report_to=None,
-        per_device_train_batch_size=1,
-        gradient_accumulation_steps=4,
-        warmup_steps=2,
-        num_train_epochs=1,
-        learning_rate=2e-4,
-        fp16=True,
-        logging_steps=1,
-        output_dir="outputs",
-        optim="paged_adamw_8bit"
-    )
 
     peft_config = LoraConfig(
         r=64,  # dimension of the updated matrices

--- a/ab/gen/train_n_eval.py
+++ b/ab/gen/train_n_eval.py
@@ -28,7 +28,7 @@ num_test_epochs = 2
 
 # Deepspeed
 use_deepspeed = False
-ds_config = os.path.join("ab","gen","deepspeed_config.json")
+ds_config = os.path.join("conf","deepspeed_config.json")
 
 def main():
     bnb_config = BitsAndBytesConfig(
@@ -41,19 +41,34 @@ def main():
     # When using deepspeed, no Training arguments' initialization after model initialization, if pre-trained model is used 
     # Reference: https://huggingface.co/docs/transformers/deepspeed?zero-config=ZeRO-3
     # With the claim: "The TrainingArguments object must be created before calling the model from_pretrained()"
-    training_args = TrainingArguments(
-        report_to=None,
-        per_device_train_batch_size=1,
-        gradient_accumulation_steps=4,
-        warmup_steps=2,
-        num_train_epochs=1,
-        learning_rate=2e-4,
-        fp16=True,
-        logging_steps=1,
-        output_dir="outputs",
-        optim="paged_adamw_8bit",
-        deepspeed=ds_config,
-    )
+    if use_deepspeed:
+        training_args = TrainingArguments(
+            report_to=None,
+            per_device_train_batch_size=1,
+            gradient_accumulation_steps=4,
+            warmup_steps=2,
+            num_train_epochs=1,
+            learning_rate=2e-4,
+            fp16=True,
+            logging_steps=1,
+            output_dir="outputs",
+            optim="paged_adamw_8bit",
+            deepspeed=ds_config,
+        )
+    else:
+        training_args = TrainingArguments(
+            report_to=None,
+            per_device_train_batch_size=1,
+            gradient_accumulation_steps=4,
+            warmup_steps=2,
+            num_train_epochs=1,
+            learning_rate=2e-4,
+            fp16=True,
+            logging_steps=1,
+            output_dir="outputs",
+            optim="paged_adamw_8bit",
+        )
+        
 
 
     # Load test prompts

--- a/ab/gen/util/LoRATrainer.py
+++ b/ab/gen/util/LoRATrainer.py
@@ -14,18 +14,9 @@ from transformers import (
     DataCollatorForLanguageModeling, PreTrainedModel, PreTrainedTokenizerBase
 )
 
-default_training_args = TrainingArguments(
-    per_device_train_batch_size=1,
-    gradient_accumulation_steps=4,
-    warmup_steps=2,
-    max_steps=20,
-    learning_rate=2e-4,
-    fp16=True,
-    logging_steps=1,
-    output_dir="outputs",
-    optim="paged_adamw_8bit",
-)
-
+# When using deepspeed, no Training arguments' initialization after model initialization, if pre-trained model is used 
+# Reference: https://huggingface.co/docs/transformers/deepspeed?zero-config=ZeRO-3
+# With the claim: "The TrainingArguments object must be created before calling the model from_pretrained()"
 
 def find_all_linear_names(model):
     cls = bnb.nn.Linear4bit
@@ -83,7 +74,7 @@ class LoRATrainer:
     def __init__(self,
                  model: PreTrainedModel,
                  tokenizer: PreTrainedTokenizerBase,
-                 training_args: TrainingArguments = default_training_args,
+                 training_args: TrainingArguments,
                  access_token=None,
                  peft_config=None
                  ):

--- a/ab/gen/util/ModelLoader.py
+++ b/ab/gen/util/ModelLoader.py
@@ -93,10 +93,8 @@ class ModelLoader:
                 print("Downloading Model...")
                 self.model = AutoModelForCausalLM.from_pretrained(
                     self.model_path,
-                    """
-                        Seems a conversion after downloading the model.
-                        This will cause error when running the script even not enabling deep speed.
-                    """
+                    # Seems a conversion after downloading the model.
+                    # This will cause error when running the script even not enabling deep speed.
                     # quantization_config=self.bnb_config, 
                     device_map="auto",
                     max_memory={i: self.max_memory for i in range(torch.cuda.device_count())},

--- a/ab/gen/util/ModelLoader.py
+++ b/ab/gen/util/ModelLoader.py
@@ -17,7 +17,8 @@ class ModelLoader:
                  bnb_config: BitsAndBytesConfig,
                  local_path=None,
                  max_memory: str = "24000MB",
-                 access_token=None
+                 access_token=None,
+                 use_deepspeed=False
                  ):
         self.model_path = model_path
         self.bnb_config = bnb_config
@@ -26,6 +27,7 @@ class ModelLoader:
         self.tokenizer = None
         self.model = None
         self.local_path = local_path
+        self.use_deepspeed = use_deepspeed
         self.initialize()
 
     def initialize(self):
@@ -46,33 +48,62 @@ class ModelLoader:
             print("Tokenizer saved to: ", "./Tokenizers/" + self.model_path)
 
         # Load the model
-        if self.local_path and os.path.exists(self.local_path):
-            print("Loading Model from local files:", "'" + self.local_path + "'")
-            self.model = AutoModelForCausalLM.from_pretrained(
-                self.local_path,
-                device_map="auto",
-                max_memory={i: self.max_memory for i in range(torch.cuda.device_count())},
-                token=self.access_token
-            )
-        elif os.path.exists("./Models/" + self.model_path + "_raw"):
-            print("Loading Model from local files:", '"./Models' + self.model_path + '_raw"')
-            self.model = AutoModelForCausalLM.from_pretrained(
-                "./Models/" + self.model_path + "_raw",
-                device_map="auto",
-                max_memory={i: self.max_memory for i in range(torch.cuda.device_count())},
-                token=self.access_token
-            )
+        if self.use_deepspeed: # When using Deepspeed, device_map should not be given, for deepspeed automatically manages the device memory mapping
+            if self.local_path and os.path.exists(self.local_path):
+                print("Loading Model from local files:", "'" + self.local_path + "'")
+                self.model = AutoModelForCausalLM.from_pretrained(
+                    self.local_path,
+                    max_memory={i: self.max_memory for i in range(torch.cuda.device_count())},
+                    token=self.access_token
+                )
+            elif os.path.exists("./Models/" + self.model_path + "_raw"):
+                print("Loading Model from local files:", '"./Models' + self.model_path + '_raw"')
+                self.model = AutoModelForCausalLM.from_pretrained(
+                    "./Models/" + self.model_path + "_raw",
+                    max_memory={i: self.max_memory for i in range(torch.cuda.device_count())},
+                    token=self.access_token
+                )
+            else:
+                print("Downloading Model...")
+                self.model = AutoModelForCausalLM.from_pretrained(
+                    self.model_path,
+                    max_memory={i: self.max_memory for i in range(torch.cuda.device_count())},
+                    token=self.access_token
+                )
+                self.model.save_pretrained("./Models/" + self.model_path + "_raw", access_token=self.access_token)
+                print("Model saved to: ", "./Models/" + self.model_path + "_raw")
         else:
-            print("Downloading Model...")
-            self.model = AutoModelForCausalLM.from_pretrained(
-                self.model_path,
-                quantization_config=self.bnb_config,
-                device_map="auto",
-                max_memory={i: self.max_memory for i in range(torch.cuda.device_count())},
-                token=self.access_token
-            )
-            self.model.save_pretrained("./Models/" + self.model_path + "_raw", access_token=self.access_token)
-            print("Model saved to: ", "./Models/" + self.model_path + "_raw")
+            if self.local_path and os.path.exists(self.local_path):
+                print("Loading Model from local files:", "'" + self.local_path + "'")
+                self.model = AutoModelForCausalLM.from_pretrained(
+                    self.local_path,
+                    device_map="auto",
+                    max_memory={i: self.max_memory for i in range(torch.cuda.device_count())},
+                    token=self.access_token
+                )
+            elif os.path.exists("./Models/" + self.model_path + "_raw"):
+                print("Loading Model from local files:", '"./Models' + self.model_path + '_raw"')
+                self.model = AutoModelForCausalLM.from_pretrained(
+                    "./Models/" + self.model_path + "_raw",
+                    device_map="auto",
+                    max_memory={i: self.max_memory for i in range(torch.cuda.device_count())},
+                    token=self.access_token
+                )
+            else:
+                print("Downloading Model...")
+                self.model = AutoModelForCausalLM.from_pretrained(
+                    self.model_path,
+                    """
+                        Seems a conversion after downloading the model.
+                        This will cause error when running the script even not enabling deep speed.
+                    """
+                    # quantization_config=self.bnb_config, 
+                    device_map="auto",
+                    max_memory={i: self.max_memory for i in range(torch.cuda.device_count())},
+                    token=self.access_token
+                )
+                self.model.save_pretrained("./Models/" + self.model_path + "_raw", access_token=self.access_token)
+                print("Model saved to: ", "./Models/" + self.model_path + "_raw")
 
     def get_model(self) -> PreTrainedModel:
         return self.model


### PR DESCRIPTION
Add optional deepspeed support.
Enable by changing use_deepspeed variable in train_n_eval.py to True, for we don't have a argument parsing for now.
TrainingArguments initialization now only exists in train_n_eval.py for it should not after the from_pretrained(), according to https://huggingface.co/docs/transformers/deepspeed?zero-config=ZeRO-3.
Only inference steps in ChatBot tested, because the LoRA part is not functional now in the original code.